### PR TITLE
[Day09] 권아영 : 모의고사

### DIFF
--- a/Day09/Ahyeong0522.java
+++ b/Day09/Ahyeong0522.java
@@ -1,0 +1,50 @@
+package Day09;
+
+import java.util.*;
+import java.util.Map.Entry;
+
+public class Ahyeong0522 {
+  public static void main(String[] args) {
+    //[1,2,3,4,5]	
+    int[] answers = {1,2,3,4,5};
+    Solution solution = new Solution();
+    System.out.println(Arrays.toString(solution.solution(answers)));
+  }
+}
+
+//수포자 3명
+// 1번 : 1,2,3,4,5 반복
+// 2번 : 2,1,2,3,2,4,2,5 반복
+// 3번 : 3,3,1,1,2,2,4,4,5,5, 반복
+
+
+class Solution {
+  public int[] solution(int[] answers) {
+      int[] first = {1,2,3,4,5};
+      int[] second = {2,1,2,3,2,4,2,5};
+      int[] third = {3,3,1,1,2,2,4,4,5,5};  
+
+      HashMap<Integer, Integer> check = new HashMap<>(); //1,2,3번의 맞춘 개수
+      check.put(1, 0);
+      check.put(2, 0);
+      check.put(3, 0);
+      
+      for (int i = 0; i < answers.length; i++) {
+        //수포자들의 찍는방식 배열에 벗어나면 다시 0으로
+        check.replace(1, first[i % first.length]==answers[i] ? check.get(1)+1 : check.get(1));
+        check.replace(2, second[i % first.length]==answers[i] ? check.get(2)+1 : check.get(2));
+        check.replace(3, third[i % first.length]==answers[i] ? check.get(3)+1 : check.get(3));             
+      }
+
+      int max = Collections.max(check.values());
+      List<Integer> answer = new ArrayList<>();
+
+      for(Map.Entry<Integer, Integer> entry : check.entrySet()){
+        if(max == entry.getValue()){
+          answer.add(entry.getKey());
+        }
+      }
+
+      return answer.stream().mapToInt(Integer::intValue).toArray();
+  }
+}

--- a/Day09/Ahyeong0522.java
+++ b/Day09/Ahyeong0522.java
@@ -24,25 +24,18 @@ class Solution {
       int[] second = {2,1,2,3,2,4,2,5};
       int[] third = {3,3,1,1,2,2,4,4,5,5};  
 
-      HashMap<Integer, Integer> check = new HashMap<>(); //1,2,3번의 맞춘 개수
-      check.put(1, 0);
-      check.put(2, 0);
-      check.put(3, 0);
-      
+      int[] check = new int[3];
       for (int i = 0; i < answers.length; i++) {
-        //수포자들의 찍는방식 배열에 벗어나면 다시 0으로
-        check.replace(1, first[i % first.length]==answers[i] ? check.get(1)+1 : check.get(1));
-        check.replace(2, second[i % first.length]==answers[i] ? check.get(2)+1 : check.get(2));
-        check.replace(3, third[i % first.length]==answers[i] ? check.get(3)+1 : check.get(3));             
+        if(first[i % first.length] == answers[i]) check[0]++;
+        if(second[i % second.length] == answers[i]) check[1]++;
+        if(third[i % third.length] == answers[i]) check[2]++;
       }
-
-      int max = Collections.max(check.values());
+      int maxCorrect = Arrays.stream(check).max().getAsInt();
       List<Integer> answer = new ArrayList<>();
-
-      for(Map.Entry<Integer, Integer> entry : check.entrySet()){
-        if(max == entry.getValue()){
-          answer.add(entry.getKey());
-        }
+      for (int i = 0; i < check.length; i++) {
+        if(check[i] == maxCorrect) {
+          answer.add(i + 1);
+        }  
       }
 
       return answer.stream().mapToInt(Integer::intValue).toArray();


### PR DESCRIPTION

### 🔗 문제링크
[모의고사](https://school.programmers.co.kr/learn/courses/30/lessons/42840)

---

### 📢 풀이 알고리즘
1. 완전 탐색
- 모든 문제를 처음부터 끝까지 반복하며 모든 정답 수 확인

---

### 💎 문제 해결

1, 2차 시도 : ❌ 
![스크린샷 2025-05-22 오후 5 23 18](https://github.com/user-attachments/assets/40c2d2d1-13c0-49ed-9c03-6ce2c8a5ff95)
</br>
3차 시도 :  ⭕️  
![스크린샷 2025-05-22 오후 6 00 49](https://github.com/user-attachments/assets/86a8b0ba-41fe-4d26-b4c7-2326e39a4549)

---

### 🔥 특이사항/질문
1차시도때는 1,2,3번 학생의 찍는 패턴의 배열을 동일한 길이로 만들어서 `if(cnt == 10) cnt=0;` 으로 초기화를 했었는데 
이부분에서 문제가 발생해 `first[i % first.length]`로 바꿨습니다.

2차시도는 삼항연산자를 사용했는데 이걸 사용하면서 해시맵이 키와 배열의 인덱스를 혼동했거나, 패턴 길이 인덱싱을 실수가 난 것 같은데... 자세하게는 모르겠습니당...ㅠ
```java
 check.replace(1, first[i % first.length]==answers[i] ? check.get(1)+1 : check.get(1));
        check.replace(2, second[i % first.length]==answers[i] ? check.get(2)+1 : check.get(2));
        check.replace(3, third[i % first.length]==answers[i] ? check.get(3)+1 : check.get(3));  
```

3차시도때는 해시맵을 버리고 그냥 `int[] check = new int[3]`으로, 삼항연산자 안쓰고 if문을 사용하여 풀었습니다^ㅠ..
HashMap쓸 때 보다 그냥 숫자 배열을  사용했을 때 시간이 짧게걸렸습니다!