### PR TITLE
[Day13] 이혜지: 전력망을 둘로 나누기

### DIFF
--- a/Day13/Hyeji0528.java
+++ b/Day13/Hyeji0528.java
@@ -1,0 +1,63 @@
+import java.util.*;
+
+class Solution {
+  public int solution(int n, int[][] wires) {
+    int answer = 99999999; // 적당히 큰 값
+    ArrayList<ArrayList<Integer>> arr = new ArrayList<>();
+    // 노드 저장용 리스트
+    boolean[] visit = new boolean[n]; // 송전탑 방문 여부
+    Queue<Integer> queue = new LinkedList<>(); // bfs용 큐
+    int cnt = 0; // 방문한 송전탑 수
+
+    for (int t = 0; t < n - 1; t++) { // 모든 전력망을 하나씩 제거하며 체크
+      cnt = 0; // 방문수 초기화
+      queue.clear(); // bfs 초기화
+      visit = new boolean[n]; // 방문 여부 초기화
+      arr = new ArrayList<>(); // 노드 초기화
+
+      for (int v = 0; v < n; v++) {
+        arr.add(new ArrayList<Integer>());
+      } // 리스트 세팅
+
+      for (int s = 0; s < n - 1; s++) {
+        if (t == s)
+          continue; // 전력망 하나 제거
+
+        int start = wires[s][0] - 1;
+        int end = wires[s][1] - 1;
+
+        arr.get(start).add(end);
+        arr.get(end).add(start);
+        // 전력망 저장
+      }
+
+      queue.add(0); // 0(1)번부터 탐색 시작
+      visit[0] = true;
+      cnt++;
+      // 방문여부 체크, 방문 수 체크
+
+      while (!queue.isEmpty()) { // bfs
+        int cur = queue.poll();
+
+        for (int i = 0; i < arr.get(cur).size(); i++) {
+          // 현재 송전탑과 연결된 송전탑 탐색
+          int next = arr.get(cur).get(i);
+
+          if (visit[next])
+            continue;
+          // 방문한 적 있는거 패스
+          queue.offer(next);
+          visit[next] = true;
+          cnt++;
+          // 다음거 방문
+        }
+      }
+
+      answer = Math.min(answer, Math.abs(n - 2 * cnt));
+      // 저장된 값과 n - cnt 와 n의 차이 비교 후 갱신
+    }
+
+    return answer;
+  }
+
+}


### PR DESCRIPTION
### 🔗 문제링크
[전력망을 둘로 나누기](https://school.programmers.co.kr/learn/courses/30/lessons/86971)

---

### 📢 풀이 알고리즘
```
완전 탐색 + BFS : 완전 탐색을 통해 제거할 전력망을 하나씩 고르고, BFS를 통해 방문가능한 송전탑의 개수를 체크.
이후, 방문한 송전탑의 개수와 방문하지 못한 송전탑의 개수의 차를 구한 뒤 답을 갱신
```

---

### 💎 문제 해결
완전 탐색 + BFS : ⭕️ 

![image](https://github.com/user-attachments/assets/3f26c42d-324b-4717-9974-a5610ef45992)

---

### 🔥 특이사항/질문

자바는 그래프 탐색을 할 때 코드가 매우 효율이 나쁨을 알 수 있는 코드입니다.
함수 분리가 번거로워 bfs로 작성했습니다. 아마 dfs로도 가능 할 것 같습니다.